### PR TITLE
Return 404 for invalid service hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # TinySvcCore
 
-Common library for TinySvc
+Common library for [TinySvc](https://www.tinysvc.com)

--- a/lib/tiny_svc/service_manager.ex
+++ b/lib/tiny_svc/service_manager.ex
@@ -2,11 +2,13 @@ defmodule TinySvc.ServiceManager do
   @services_dir "services"
   alias TinySvc.Service
 
-  def find(service_name) do
-    case File.exists?("#{@services_dir}/#{service_name}") do
+  @deps [file: File]
+
+  def find(service_name, deps \\ @deps) do
+    case deps[:file].exists?("#{@services_dir}/#{service_name}") do
       true ->
         %Service{name: service_name}
-      false -> raise "Service #{service_name} not found!"
+      false -> nil
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule TinySvcCore.Mixfile do
 
   def project do
     [app: :tiny_svc_core,
-     version: "0.1.0",
+     version: "0.1.1",
      elixir: "~> 1.4",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/test/plug/tiny_service_gateway_test.exs
+++ b/test/plug/tiny_service_gateway_test.exs
@@ -85,6 +85,15 @@ defmodule Plug.TinyServiceGatewayTest do
       assert conn.state == :sent
     end
 
+    test "sends 404 when service manager finds no matching service" do
+      opts = stub_opts()
+      conn = conn(:get, "http://invalid-service.tinysvc.dev/hello")
+      conn = GatewayPlug.call(conn, opts)
+      refute_receive({:invoke, _service, _, _})
+      assert conn.status == 404
+      assert conn.state == :sent
+    end
+
     test "puts path_params into params" do
       function_router_stub = FunctionRouter
       |> double
@@ -208,6 +217,7 @@ defmodule Plug.TinyServiceGatewayTest do
 
     service_manager_stub = TinySvc.ServiceManager
     |> double
+    |> allow(:find, fn("invalid-service") -> nil end)
     |> allow(:find, fn(name) -> %Service{name: name} end)
 
     [invoker: invoker_stub, router: router_stub, service_manager: service_manager_stub]

--- a/test/tiny_svc/service_manager_test.exs
+++ b/test/tiny_svc/service_manager_test.exs
@@ -1,0 +1,22 @@
+defmodule TinySvc.ServiceManagerTest do
+  use ExUnit.Case
+  import Double
+  alias TinySvc.Service
+  alias TinySvc.ServiceManager
+
+  test "returns a service struct" do
+    result = ServiceManager.find("test-service", [file: file_stub(true)])
+    assert result == %Service{name: "test-service"}
+  end
+
+  test "when missing, returns nil" do
+    result = ServiceManager.find("test-service", [file: file_stub(false)])
+    assert result == nil
+  end
+
+  defp file_stub(result) do
+    File
+    |> double
+    |> allow(:exists?, fn("services/test-service") -> result end)
+  end
+end


### PR DESCRIPTION
Instead of raising an exception, we're just going to return a 404 when a request is made to a subdomain that has no service associated.  